### PR TITLE
Downgrade postgres

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -63,5 +63,5 @@ databases:
   - name: cred
     databaseName: cred
     region: oregon
-    plan: pro plus
+    plan: standard
     postgresMajorVersion: 15


### PR DESCRIPTION
We don't need the pro plus plan anymore since we stopped storing the transfer events.